### PR TITLE
Fix: Crypto LatestVolume type

### DIFF
--- a/altdata.go
+++ b/altdata.go
@@ -22,7 +22,7 @@ type CryptoQuote struct {
 	LatestSource          string    `json:"latestSource"`
 	LatestTime            string    `json:"latestTime"`
 	LatestUpdate          EpochTime `json:"latestUpdate"`
-	LatestVolume          int       `json:"latestVolume"`
+	LatestVolume          float64   `json:"latestVolume"`
 	IEXRealtimePrice      float64   `json:"iexRealtimePrice"`
 	IEXRealtimeSize       int       `json:"iexRealtimeSize"`
 	IEXLastUpdated        EpochTime `json:"iexLastUpdated"`


### PR DESCRIPTION
Fixes unmarshaling issue with Crypto volumes: 

```
json: cannot unmarshal number 521031.349 into Go struct field Crypt
oQuote.latestVolume of type int
```