### PR TITLE
Move chartByDay param to options

### DIFF
--- a/client.go
+++ b/client.go
@@ -308,7 +308,7 @@ func (c Client) IntradayHistoricalPrices(ctx context.Context, symbol string, opt
 // IntradayHistoricalPricesByDay retrieves intraday historical market-wide data for a given day
 func (c Client) IntradayHistoricalPricesByDay(ctx context.Context, symbol string, day time.Time, options *IntradayHistoricalOptions) ([]IntradayHistoricalDataPoint, error) {
 	h := make([]IntradayHistoricalDataPoint, 0)
-	endpoint := fmt.Sprintf("/stock/%s/chart/date/%s?chartByDay=true",
+	endpoint := fmt.Sprintf("/stock/%s/chart/date/%s",
 		url.PathEscape(symbol), day.Format("20060102"))
 	endpoint, err := c.intradayHistoricalEndpointWithOpts(endpoint, options, true)
 	if err != nil {

--- a/historical.go
+++ b/historical.go
@@ -80,6 +80,7 @@ type HistoricalOptions struct {
 // IntradayHistoricalOptions optional query params to pass to intraday historical endpoint
 // If values are false or 0 they aren't passed.
 type IntradayHistoricalOptions struct {
+	ChartByDay      bool `url:"chartByDay,omitempty"`
 	ChartIEXOnly    bool `url:"chartIEXOnly,omitempty"`
 	ChartReset      bool `url:"chartReset,omitempty"`
 	ChartSimplify   bool `url:"chartSimplify,omitempty"`


### PR DESCRIPTION
The chartByDay parameter has been hard-coded into the endpoint, as a result it won't be able to fetch intraday data and client is not able to change the setting.