### PR TITLE
Fix historicalPricesByDay implementation

### DIFF
--- a/client.go
+++ b/client.go
@@ -265,7 +265,7 @@ func (c Client) HistoricalPrices(ctx context.Context, symbol string, timeframe H
 // HistoricalPricesByDay retrieves historically adjusted market-wide data for a given day
 func (c Client) HistoricalPricesByDay(ctx context.Context, symbol string, day time.Time, options *HistoricalOptions) ([]HistoricalDataPoint, error) {
 	h := make([]HistoricalDataPoint, 0)
-	endpoint := fmt.Sprintf("/stock/%s/chart/date/%s",
+	endpoint := fmt.Sprintf("/stock/%s/chart/date/%s?chartByDay=true",
 		url.PathEscape(symbol), day.Format("20060102"))
 	endpoint, err := c.historicalEndpointWithOpts(endpoint, options)
 	if err != nil {
@@ -308,7 +308,7 @@ func (c Client) IntradayHistoricalPrices(ctx context.Context, symbol string, opt
 // IntradayHistoricalPricesByDay retrieves intraday historical market-wide data for a given day
 func (c Client) IntradayHistoricalPricesByDay(ctx context.Context, symbol string, day time.Time, options *IntradayHistoricalOptions) ([]IntradayHistoricalDataPoint, error) {
 	h := make([]IntradayHistoricalDataPoint, 0)
-	endpoint := fmt.Sprintf("/stock/%s/chart/date/%s?chartByDay=true",
+	endpoint := fmt.Sprintf("/stock/%s/chart/date/%s",
 		url.PathEscape(symbol), day.Format("20060102"))
 	endpoint, err := c.intradayHistoricalEndpointWithOpts(endpoint, options, true)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/goinvest/iexcloud/v2
+module github.com/GrandNewbien/iexcloud/v2
 
 require (
 	github.com/BurntSushi/toml v0.3.1

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/GrandNewbien/iexcloud/v2
+module github.com/goinvest/iexcloud/v2
 
 require (
 	github.com/BurntSushi/toml v0.3.1


### PR DESCRIPTION
This is a fix for https://github.com/goinvest/iexcloud/issues/68

In the docs of https://iexcloud.io/docs/api/#historical_prices, it states that only when you combine this with chartByDay=true this returns historical OHLCV data for that date. Otherwise, it returns data by minute for a specified date, if available. Therefore your implementations are switched. For HistoricalPricesByDay u need the chartByDay parameter. For IntradayHistoricalPricesByDay, you ignore it. Verified in sandbox and prod environments.

Reviewers
@matthewrankin 