### PR TITLE
Added OptionsSymbols to client

### DIFF
--- a/client.go
+++ b/client.go
@@ -419,11 +419,17 @@ func (c Client) Quote(ctx context.Context, symbol string) (Quote, error) {
 }
 
 // BatchQuote returns the quote data for up to 100 stock symbols.
-func (c Client) BatchQuote(ctx context.Context, symbols []string) ([]Quote, error) {
-	var r []Quote
+func (c Client) BatchQuote(ctx context.Context, symbols []string) (map[string]Quote, error) {
+	r := map[string]struct {
+		Quote Quote
+	}{}
 	endpoint := fmt.Sprintf("/stock/market/batch?symbols=%s&types=quote", url.PathEscape(strings.Join(symbols, ",")))
 	err := c.GetJSON(ctx, endpoint, &r)
-	return r, err
+	quotes := make(map[string]Quote, len(r))
+	for symbol, quote := range r {
+		quotes[symbol] = quote.Quote
+	}
+	return quotes, err
 }
 
 // VolumeByVenue returns the 15 minute delayed and 30 day average consolidated

--- a/client.go
+++ b/client.go
@@ -418,6 +418,14 @@ func (c Client) Quote(ctx context.Context, symbol string) (Quote, error) {
 	return r, err
 }
 
+// BatchQuote returns the quote data for up to 100 stock symbols.
+func (c Client) BatchQuote(ctx context.Context, symbols []string) ([]Quote, error) {
+	var r []Quote
+	endpoint := fmt.Sprintf("/stock/market/batch?symbols=%s&types=quote", url.PathEscape(strings.Join(symbols, ",")))
+	err := c.GetJSON(ctx, endpoint, &r)
+	return r, err
+}
+
 // VolumeByVenue returns the 15 minute delayed and 30 day average consolidated
 // volume percentage of a stock by market. This will return 13 values sorted in
 // ascending order by current day trading volume percentage.

--- a/client.go
+++ b/client.go
@@ -1116,6 +1116,15 @@ func (c Client) MutualFundSymbols(ctx context.Context) ([]Symbol, error) {
 	return r, err
 }
 
+// OptionsSymbols returns a map keyed by symbol with the value of each symbol
+// being an slice of available contract dates
+func (c Client) OptionsSymbols(ctx context.Context) (map[string][]string, error) {
+	r := map[string][]string{}
+	endpoint := "/ref-data/options/symbols"
+	err := c.GetJSON(ctx, endpoint, &r)
+	return r, err
+}
+
 // OTCSymbols returns an array of Over-the-Counter (OTC) stocks that IEX Cloud
 // supports for API calls.
 func (c Client) OTCSymbols(ctx context.Context) ([]Symbol, error) {


### PR DESCRIPTION
Missing request endpoint added: https://iexcloud.io/docs/api/#options-symbols

Notice that this endpoint is overly simplistic and does not warrant an actual struct do to the format of the JSON returned.