### PR TITLE
Fix a bug that didn't return any data for batch previous.

### DIFF
--- a/client.go
+++ b/client.go
@@ -452,13 +452,13 @@ func (c Client) BatchQuote(ctx context.Context, symbols []string) (map[string]Qu
 // BatchPrevious returns the previous day price for up to 100 stock symbols.
 func (c Client) BatchPrevious(ctx context.Context, symbols []string) (map[string]PreviousDay, error) {
 	r := map[string]struct {
-		PreviousDay PreviousDay
+		Previous PreviousDay
 	}{}
 	endpoint := fmt.Sprintf("/stock/market/batch?symbols=%s&types=previous", url.PathEscape(strings.Join(symbols, ",")))
 	err := c.GetJSON(ctx, endpoint, &r)
 	previousday := make(map[string]PreviousDay, len(r))
 	for symbol, quote := range r {
-		previousday[symbol] = quote.PreviousDay
+		previousday[symbol] = quote.Previous
 	}
 	return previousday, err
 }


### PR DESCRIPTION
The JSON structure we get from IEX cloud is slightly different than what
the library was expecting. The data falls under a key called "previous",
not "previous_day" which we were expecting. Now the batch query returns
data because the JSON is being parsed correctly.

Note that [this pull request](https://github.com/goinvest/iexcloud-examples/pull/2) makes it possible to quickly verify that this change works as intended by using the examples CLI to query the previous day's data for multiple symbols.