### PR TITLE
Add a "limit" parameter to all "list" commands.

### DIFF
--- a/client.go
+++ b/client.go
@@ -102,6 +102,7 @@ func (c *Client) GetJSON(ctx context.Context, endpoint string, v interface{}) er
 	return c.FetchURLToJSON(ctx, u, v)
 }
 
+// GetJSONWithQueryParams gets the JSON data from the given endpoint with the query parameters attached.
 func (c *Client) GetJSONWithQueryParams(ctx context.Context, endpoint string, queryParams map[string]string, v interface{}) error {
 	u, err := c.url(endpoint, queryParams)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -177,13 +177,8 @@ func (c *Client) getBytes(ctx context.Context, address string) ([]byte, error) {
 
 // Adds the client's token to the URL.
 func (c *Client) addToken(u *url.URL) {
-	addQueryParam("token", c.token, u)
-}
-
-// Adds the name and value to the URL's query parameters.
-func addQueryParam(name string, value string, u *url.URL) {
 	v := u.Query()
-	v.Add(name, value)
+	v.Add("token", c.token)
 	u.RawQuery = v.Encode()
 }
 
@@ -195,9 +190,11 @@ func (c *Client) url(endpoint string, queryParams map[string]string) (*url.URL, 
 	}
 	u.Path = path.Join(u.Path, endpoint)
 	if queryParams != nil {
+		q := u.Query()
 		for k, v := range queryParams {
-			addQueryParam(k, v, u)
+			q.Add(k, v)
 		}
+		u.RawQuery = q.Encode()
 	}
 	return u, nil
 }

--- a/client.go
+++ b/client.go
@@ -94,21 +94,20 @@ func WithBaseURL(baseURL string) func(*Client) {
 
 // GetJSON gets the JSON data from the given endpoint.
 func (c *Client) GetJSON(ctx context.Context, endpoint string, v interface{}) error {
-	u, err := c.url(endpoint, nil)
+	u, err := c.url(endpoint, map[string]string{"token": c.token})
 	if err != nil {
 		return err
 	}
-	c.addToken(u)
 	return c.FetchURLToJSON(ctx, u, v)
 }
 
 // GetJSONWithQueryParams gets the JSON data from the given endpoint with the query parameters attached.
 func (c *Client) GetJSONWithQueryParams(ctx context.Context, endpoint string, queryParams map[string]string, v interface{}) error {
+	queryParams["token"] = c.token
 	u, err := c.url(endpoint, queryParams)
 	if err != nil {
 		return err
 	}
-	c.addToken(u)
 	return c.FetchURLToJSON(ctx, u, v)
 }
 
@@ -133,11 +132,10 @@ func (c *Client) GetJSONWithoutToken(ctx context.Context, endpoint string, v int
 
 // GetBytes gets the data from the given endpoint.
 func (c *Client) GetBytes(ctx context.Context, endpoint string) ([]byte, error) {
-	u, err := c.url(endpoint, nil)
+	u, err := c.url(endpoint, map[string]string{"token": c.token})
 	if err != nil {
 		return nil, err
 	}
-	c.addToken(u)
 	return c.getBytes(ctx, u.String())
 }
 
@@ -173,13 +171,6 @@ func (c *Client) getBytes(ctx context.Context, address string) ([]byte, error) {
 		return []byte{}, Error{StatusCode: resp.StatusCode, Message: msg}
 	}
 	return ioutil.ReadAll(resp.Body)
-}
-
-// Adds the client's token to the URL.
-func (c *Client) addToken(u *url.URL) {
-	v := u.Query()
-	v.Add("token", c.token)
-	u.RawQuery = v.Encode()
 }
 
 // Returns an URL object that points to the endpoint with optional query parameters.

--- a/client.go
+++ b/client.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -93,11 +94,26 @@ func WithBaseURL(baseURL string) func(*Client) {
 
 // GetJSON gets the JSON data from the given endpoint.
 func (c *Client) GetJSON(ctx context.Context, endpoint string, v interface{}) error {
-	address, err := c.addToken(endpoint)
+	u, err := c.url(endpoint, nil)
 	if err != nil {
 		return err
 	}
-	data, err := c.getBytes(ctx, address)
+	c.addToken(u)
+	return c.FetchURLToJSON(ctx, u, v)
+}
+
+func (c *Client) GetJSONWithQueryParams(ctx context.Context, endpoint string, queryParams map[string]string, v interface{}) error {
+	u, err := c.url(endpoint, queryParams)
+	if err != nil {
+		return err
+	}
+	c.addToken(u)
+	return c.FetchURLToJSON(ctx, u, v)
+}
+
+// Fetches JSON content from the given URL and unmarshals it into `v`.
+func (c *Client) FetchURLToJSON(ctx context.Context, u *url.URL, v interface{}) error {
+	data, err := c.getBytes(ctx, u.String())
 	if err != nil {
 		return err
 	}
@@ -107,21 +123,21 @@ func (c *Client) GetJSON(ctx context.Context, endpoint string, v interface{}) er
 // GetJSONWithoutToken gets the JSON data from the given endpoint without
 // adding a token to the URL.
 func (c *Client) GetJSONWithoutToken(ctx context.Context, endpoint string, v interface{}) error {
-	address := c.baseURL + endpoint
-	data, err := c.getBytes(ctx, address)
+	u, err := c.url(endpoint, nil)
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(data, v)
+	return c.FetchURLToJSON(ctx, u, v)
 }
 
 // GetBytes gets the data from the given endpoint.
 func (c *Client) GetBytes(ctx context.Context, endpoint string) ([]byte, error) {
-	address, err := c.addToken(endpoint)
+	u, err := c.url(endpoint, nil)
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
-	return c.getBytes(ctx, address)
+	c.addToken(u)
+	return c.getBytes(ctx, u.String())
 }
 
 // GetFloat64 gets the number from the given endpoint.
@@ -158,15 +174,31 @@ func (c *Client) getBytes(ctx context.Context, address string) ([]byte, error) {
 	return ioutil.ReadAll(resp.Body)
 }
 
-func (c *Client) addToken(endpoint string) (string, error) {
-	u, err := url.Parse(c.baseURL + endpoint)
-	if err != nil {
-		return "", err
-	}
+// Adds the client's token to the URL.
+func (c *Client) addToken(u *url.URL) {
+	addQueryParam("token", c.token, u)
+}
+
+// Adds the name and value to the URL's query parameters.
+func addQueryParam(name string, value string, u *url.URL) {
 	v := u.Query()
-	v.Add("token", c.token)
+	v.Add(name, value)
 	u.RawQuery = v.Encode()
-	return u.String(), nil
+}
+
+// Returns an URL object that points to the endpoint with optional query parameters.
+func (c *Client) url(endpoint string, queryParams map[string]string) (*url.URL, error) {
+	u, err := url.Parse(c.baseURL)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = path.Join(u.Path, endpoint)
+	if queryParams != nil {
+		for k, v := range queryParams {
+			addQueryParam(k, v, u)
+		}
+	}
+	return u, nil
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -770,44 +802,48 @@ func (c Client) IPOsToday(ctx context.Context) (IPOCalendar, error) {
 
 // MostActive returns a list of quotes for the top 10 most active stocks from
 // the IEX Cloud endpoint updated intraday, 15 minute delayed.
-func (c Client) MostActive(ctx context.Context) ([]Quote, error) {
-	return c.list(ctx, "mostactive")
+func (c Client) MostActive(ctx context.Context, limit int) ([]Quote, error) {
+	return c.list(ctx, "mostactive", limit)
 }
 
 // Gainers returns a list of quotes for the top 10 stock gainers from
 // the IEX Cloud endpoint updated intraday, 15 minute delayed.
-func (c Client) Gainers(ctx context.Context) ([]Quote, error) {
-	return c.list(ctx, "gainers")
+func (c Client) Gainers(ctx context.Context, limit int) ([]Quote, error) {
+	return c.list(ctx, "gainers", limit)
 }
 
 // Losers returns a list of quotes for the top 10 stock losers from
 // the IEX Cloud endpoint updated intraday, 15 minute delayed.
-func (c Client) Losers(ctx context.Context) ([]Quote, error) {
-	return c.list(ctx, "losers")
+func (c Client) Losers(ctx context.Context, limit int) ([]Quote, error) {
+	return c.list(ctx, "losers", limit)
 }
 
 // IEXVolume returns a list of quotes for the top 10 IEX stocks by volume from
 // the IEX Cloud endpoint updated intraday, 15 minute delayed.
-func (c Client) IEXVolume(ctx context.Context) ([]Quote, error) {
-	return c.list(ctx, "iexvolume")
+func (c Client) IEXVolume(ctx context.Context, limit int) ([]Quote, error) {
+	return c.list(ctx, "iexvolume", limit)
 }
 
 // IEXPercent returns a list of quotes for the top 10 IEX stocks by percent
 // from the IEX Cloud endpoint updated intraday, 15 minute delayed.
-func (c Client) IEXPercent(ctx context.Context) ([]Quote, error) {
-	return c.list(ctx, "iexpercent")
+func (c Client) IEXPercent(ctx context.Context, limit int) ([]Quote, error) {
+	return c.list(ctx, "iexpercent", limit)
 }
 
 // InFocus returns a list of quotes for the top 10 in focus stocks from the IEX
 // Cloud endpoint updated intraday, 15 minute delayed.
-func (c Client) InFocus(ctx context.Context) ([]Quote, error) {
-	return c.list(ctx, "infocus")
+func (c Client) InFocus(ctx context.Context, limit int) ([]Quote, error) {
+	return c.list(ctx, "infocus", limit)
 }
 
-func (c Client) list(ctx context.Context, list string) ([]Quote, error) {
+func (c Client) list(ctx context.Context, list string, limit int) ([]Quote, error) {
 	q := []Quote{}
 	endpoint := "/stock/market/list/" + list
-	err := c.GetJSON(ctx, endpoint, &q)
+	params := make(map[string]string)
+	if limit > 0 {
+		params["listLimit"] = fmt.Sprintf("%d", limit)
+	}
+	err := c.GetJSONWithQueryParams(ctx, endpoint, params, &q)
 	return q, err
 }
 


### PR DESCRIPTION
This limits the results to the value given, which can impact the amount of credits you use per query.

This change also cleans up the code a little bit to make generating a URL query a little more flexible and less error-prone. For example now it uses path.Join() instead of string concatenation, and it generates the URL in a separate function so it's not so tightly coupled.