### PR TITLE
Added unit tests

### DIFF
--- a/client.go
+++ b/client.go
@@ -281,22 +281,21 @@ func (c Client) AnalystRecommendationsAndTargets(ctx context.Context, symbol str
 // AnnualBalanceSheets returns the specified number of most recent annual
 // balance sheets from the IEX Cloud endpoint for the given stock symbol.
 func (c Client) AnnualBalanceSheets(ctx context.Context, symbol string, num int) (BalanceSheets, error) {
-	endpoint := fmt.Sprintf("/stock/%s/balance-sheet/%d?period=annual",
-		url.PathEscape(symbol), num)
-	return c.balanceSheets(ctx, endpoint)
+	return c.BalanceSheets(ctx, symbol, "annual", num)
 }
 
 // QuarterlyBalanceSheets returns the specified number of most recent quarterly
 // balance sheets from the IEX Cloud endpoint for the given stock symbol.
 func (c Client) QuarterlyBalanceSheets(ctx context.Context, symbol string, num int) (BalanceSheets, error) {
-	endpoint := fmt.Sprintf("/stock/%s/balance-sheet/%d?period=quarter",
-		url.PathEscape(symbol), num)
-	return c.balanceSheets(ctx, endpoint)
+	return c.BalanceSheets(ctx, symbol, "quarter", num)
 }
 
-func (c Client) balanceSheets(ctx context.Context, endpoint string) (BalanceSheets, error) {
+// BalanceSheets returns the specified number of most recent balance sheets
+// with the given period (either "annual" or "quarter").
+func (c Client) BalanceSheets(ctx context.Context, symbol, period string, num int) (BalanceSheets, error) {
+	endpoint := fmt.Sprintf("/stock/%s/balance-sheet/%d", url.PathEscape(symbol), num)
 	bs := BalanceSheets{}
-	err := c.GetJSON(ctx, endpoint, &bs)
+	err := c.GetJSONWithQueryParams(ctx, endpoint, map[string]string{"period": period}, &bs)
 	return bs, err
 }
 

--- a/client.go
+++ b/client.go
@@ -37,21 +37,24 @@ type Error struct {
 	Message    string
 }
 
+// ClientOption applies an option to the client.
+type ClientOption func(*Client)
+
 // Error implements the error interface
 func (e Error) Error() string {
 	return fmt.Sprintf("%d %s: %s", e.StatusCode, http.StatusText(e.StatusCode), e.Message)
 }
 
 // NewClient creates a client with the given authorization token.
-func NewClient(token string, options ...func(*Client)) *Client {
+func NewClient(token string, options ...ClientOption) *Client {
 	client := &Client{
 		token:      token,
 		httpClient: &http.Client{Timeout: time.Second * 60},
 	}
 
 	// apply options
-	for _, option := range options {
-		option(client)
+	for _, applyOption := range options {
+		applyOption(client)
 	}
 
 	// set default values
@@ -63,14 +66,14 @@ func NewClient(token string, options ...func(*Client)) *Client {
 }
 
 // WithHTTPClient sets the http.Client for a new IEX Client
-func WithHTTPClient(httpClient *http.Client) func(*Client) {
+func WithHTTPClient(httpClient *http.Client) ClientOption {
 	return func(client *Client) {
 		client.httpClient = httpClient
 	}
 }
 
 // WithSecureHTTPClient sets a secure http.Client for a new IEX Client
-func WithSecureHTTPClient() func(*Client) {
+func WithSecureHTTPClient() ClientOption {
 	return func(client *Client) {
 		client.httpClient = &http.Client{
 			Transport: &http.Transport{
@@ -86,7 +89,7 @@ func WithSecureHTTPClient() func(*Client) {
 }
 
 // WithBaseURL sets the baseURL for a new IEX Client
-func WithBaseURL(baseURL string) func(*Client) {
+func WithBaseURL(baseURL string) ClientOption {
 	return func(client *Client) {
 		client.baseURL = baseURL
 	}

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -3,7 +3,6 @@
 // Use of this source code is governed by a MIT-style license that
 // can be found in the LICENSE file for the project.
 
-//go:build integration
 // +build integration
 
 package iex

--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2019-2022 The iexcloud developers. All rights reserved.
+// Project site: https://github.com/goinvest/iexcloud
+// Use of this source code is governed by a MIT-style license that
+// can be found in the LICENSE file for the project.
+
+//go:build integration
+// +build integration
+
+package iex
+
+import (
+	"context"
+	"io/ioutil"
+	"log"
+	"math"
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Config contains the configuration information neecded to program and test
+// the adapaters.
+type Config struct {
+	Token   string
+	BaseURL string
+}
+
+// ReadConfig will read the TOML config file.
+func readConfig(configFile string) (Config, error) {
+
+	var cfg Config
+
+	// Read config file
+	f, err := os.Open(configFile)
+	if err != nil {
+		return cfg, err
+	}
+	defer f.Close()
+	buf, err := ioutil.ReadAll(f)
+	if err != nil {
+		return cfg, err
+	}
+	err = toml.Unmarshal(buf, &cfg)
+	return cfg, err
+}
+
+func TestIntegrationAnnualBalanceSheets(t *testing.T) {
+	cfg, err := readConfig("config_test.toml")
+	if err != nil {
+		log.Fatalf("Error reading config file: %s", err)
+	}
+	client := NewClient(cfg.Token, WithBaseURL(cfg.BaseURL))
+	bs, err := client.AnnualBalanceSheets(context.Background(), "aapl", 4)
+	if err != nil {
+		log.Fatalf("Error getting balance sheets: %s", err)
+	}
+	assertString(t, "symbol", bs.Symbol, "AAPL")
+	assertInt(t, "number of years", len(bs.Statements), 4)
+	q1 := bs.Statements[0]
+	assertString(t, "filing type", q1.FilingType, "10-K")
+	assertInt(t, "fiscal quarter", q1.FiscalQuarter, 0)
+	isPositiveInt(t, "fiscal year", q1.FiscalYear)
+	assertString(t, "currency", q1.Currency, "USD")
+}
+
+func TestIntegrationQuarterlyBalanceSheets(t *testing.T) {
+	cfg, err := readConfig("config_test.toml")
+	if err != nil {
+		log.Fatalf("Error reading config file: %s", err)
+	}
+	client := NewClient(cfg.Token, WithBaseURL(cfg.BaseURL))
+	bs, err := client.QuarterlyBalanceSheets(context.Background(), "aapl", 2)
+	if err != nil {
+		log.Fatalf("Error getting balance sheets: %s", err)
+	}
+	assertString(t, "symbol", bs.Symbol, "AAPL")
+	assertInt(t, "number of quarters", len(bs.Statements), 2)
+	q1 := bs.Statements[0]
+	assertString(t, "filing type", q1.FilingType, "10-K")
+	isPositiveInt(t, "fiscal quarter", q1.FiscalQuarter)
+	isPositiveInt(t, "fiscal year", q1.FiscalYear)
+	assertString(t, "currency", q1.Currency, "USD")
+}
+
+func TestIntegrationBook(t *testing.T) {
+	cfg, err := readConfig("config_test.toml")
+	if err != nil {
+		log.Fatalf("Error reading config file: %s", err)
+	}
+	client := NewClient(cfg.Token, WithBaseURL(cfg.BaseURL))
+	got, err := client.Book(context.Background(), "aapl")
+	if err != nil {
+		log.Fatalf("Error getting book: %s", err)
+	}
+	assertString(t, "symbol", got.Quote.Symbol, "AAPL")
+	assertString(t, "company name", got.Quote.CompanyName, "Apple Inc")
+	assertScrambledString(t, "primary exchange", got.Quote.PrimaryExchange, "NASDAQ")
+	assertString(t, "calculation price", got.Quote.CalculationPrice, "close")
+	isPositiveFloat64(t, "open", got.Quote.Open)
+	assertScrambledString(t, "open source", got.Quote.OpenSource, "official")
+	isPositiveFloat64(t, "latest price", got.Quote.LatestPrice)
+}
+
+func TestIntegrationHistoricalPrices(t *testing.T) {
+	cfg, err := readConfig("config_test.toml")
+	if err != nil {
+		log.Fatalf("Error reading config file: %s", err)
+	}
+	client := NewClient(cfg.Token, WithBaseURL(cfg.BaseURL))
+	timeframe := OneMonthHistorical
+	histPrices, err := client.HistoricalPrices(context.Background(), "aapl", timeframe, nil)
+	if err != nil {
+		log.Fatalf("Error getting historical prices: %s", err)
+	}
+	got := histPrices[0]
+	isPositiveFloat64(t, "close", got.Close)
+	isPositiveFloat64(t, "high", got.High)
+	isPositiveFloat64(t, "low", got.Low)
+	isPositiveFloat64(t, "open", got.Open)
+	assertString(t, "symbol", got.Symbol, "AAPL")
+	isPositiveInt(t, "volume", got.Volume)
+	assertScrambledString(t, "id", got.ID, "HISTORICAL_PRICES")
+	assertScrambledString(t, "key", got.Key, "AAPL")
+	assertString(t, "subkey", got.Subkey, "")
+}
+
+func assertInt(t *testing.T, label string, got, want int) {
+	if got != want {
+		t.Errorf("\t got = %d %s\n\t\twant = %d", got, label, want)
+	}
+}
+
+func assertFloat64(t *testing.T, label string, got, want, tolerance float64) {
+	if diff := math.Abs(want - got); diff >= tolerance {
+		t.Errorf("\t got = %f %s\n\t\t\twant = %f", got, label, want)
+	}
+}
+
+func assertBool(t *testing.T, label string, got, want bool) {
+	if got != want {
+		t.Errorf("\t got = %t %s\n\t\t\twant = %t", got, label, want)
+	}
+}
+
+func assertString(t *testing.T, label string, got, want string) {
+	if got != want {
+		t.Errorf("\t got = %s %s\n\t\t\twant = %s", got, label, want)
+	}
+}
+
+// IEX scrambles their responses when using the testing sandbox. Therefore, the
+// best we can do is assert that all the letters are there even if scrambled.
+func assertScrambledString(t *testing.T, label string, got, want string) {
+	gotSorted := sortString(got)
+	wantSorted := sortString(want)
+	if gotSorted != wantSorted {
+		t.Errorf("\t got = %s %s\n\t\t\twant = %s", got, label, want)
+	}
+}
+
+func isPositiveInt(t *testing.T, label string, got int) {
+	if got <= 0 {
+		t.Errorf("\t got = %d %s\n\t\twant int > 0", got, label)
+	}
+}
+
+func isPositiveFloat64(t *testing.T, label string, got float64) {
+	if got <= 0.0 {
+		t.Errorf("\t got = %f %s\n\t\twant float64 > 0.0", got, label)
+	}
+}
+
+func isString(t *testing.T, label string, got string) {
+	if got == "" {
+		t.Errorf("\t got = %s %s\n\t\twant non-empty string", got, label)
+	}
+}
+
+type sortRunes []rune
+
+func (s sortRunes) Less(i, j int) bool {
+	return s[i] < s[j]
+}
+
+func (s sortRunes) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s sortRunes) Len() int {
+	return len(s)
+}
+
+func sortString(s string) string {
+	r := []rune(s)
+	sort.Sort(sortRunes(r))
+	return string(r)
+}

--- a/client_test.go
+++ b/client_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -18,43 +19,161 @@ import (
 
 const testToken = "not-a-real-token"
 
-// func TestAnnualBalanceSheets(t *testing.T) {
-// 	cfg, err := readConfig("config_test.toml")
-// 	if err != nil {
-// 		log.Fatalf("Error reading config file: %s", err)
-// 	}
-// 	client := iex.NewClient(cfg.Token, iex.WithBaseURL(cfg.BaseURL))
-// 	bs, err := client.AnnualBalanceSheets(context.Background(), "aapl", 4)
-// 	if err != nil {
-// 		log.Fatalf("Error getting balance sheets: %s", err)
-// 	}
-// 	assertString(t, "symbol", bs.Symbol, "AAPL")
-// 	assertInt(t, "number of years", len(bs.Statements), 4)
-// 	q1 := bs.Statements[0]
-// 	assertString(t, "filing type", q1.FilingType, "10-K")
-// 	assertInt(t, "fiscal quarter", q1.FiscalQuarter, 0)
-// 	isPositiveInt(t, "fiscal year", q1.FiscalYear)
-// 	assertString(t, "currency", q1.Currency, "USD")
-// }
+// Returns the base address for the given test server.
+func baseAddress(s *httptest.Server) ClientOption {
+	return WithBaseURL("http://" + s.Listener.Addr().String())
+}
 
-// func TestQuarterlyBalanceSheets(t *testing.T) {
-// 	cfg, err := readConfig("config_test.toml")
-// 	if err != nil {
-// 		log.Fatalf("Error reading config file: %s", err)
-// 	}
-// 	client := iex.NewClient(cfg.Token, iex.WithBaseURL(cfg.BaseURL))
-// 	bs, err := client.QuarterlyBalanceSheets(context.Background(), "aapl", 2)
-// 	if err != nil {
-// 		log.Fatalf("Error getting balance sheets: %s", err)
-// 	}
-// 	assertString(t, "symbol", bs.Symbol, "AAPL")
-// 	assertInt(t, "number of quarters", len(bs.Statements), 2)
-// 	q1 := bs.Statements[0]
-// 	assertString(t, "filing type", q1.FilingType, "10-K")
-// 	isPositiveInt(t, "fiscal quarter", q1.FiscalQuarter)
-// 	isPositiveInt(t, "fiscal year", q1.FiscalYear)
-// 	assertString(t, "currency", q1.Currency, "USD")
-// }
+func TestBalanceSheets(t *testing.T) {
+	fakeIEX := fakeiexcloud.FakeIEXCloud{}
+	s := httptest.NewServer(http.HandlerFunc(fakeIEX.Handle))
+	defer s.Close()
+	client := NewClient(testToken, baseAddress(s))
+
+	const nominalBalanceSheetJSON = `{
+		"symbol": "AAPL",
+		"balancesheet": [
+			{
+				"reportDate": "2020-10-17",
+				"filingType": "10-K",
+				"fiscalDate": "2020-09-13",
+				"fiscalQuarter": 4,
+				"fiscalYear": 2010,
+				"currency": "USD",
+				"currentCash": 25913000000,
+				"shortTermInvestments": null,
+				"receivables": 23186000000,
+				"inventory": 3956000000,
+				"otherCurrentAssets": 12087000000,
+				"currentAssets": 131339000000,
+				"longTermInvestments": 170799000000,
+				"propertyPlantEquipment": 41304000000,
+				"goodwill": null,
+				"intangibleAssets": null,
+				"otherAssets": 22283000000,
+				"totalAssets": 365725000000,
+				"accountsPayable": 55888000000,
+				"currentLongTermDebt": null,
+				"otherCurrentLiabilities": null,
+				"totalCurrentLiabilities": 116866000000,
+				"longTermDebt": 93735000000,
+				"otherLiabilities": null,
+				"minorityInterest": 0,
+				"totalLiabilities": 258578000000,
+				"commonStock": 40201000000,
+				"retainedEarnings": 70400000000,
+				"treasuryStock": null,
+				"capitalSurplus": null,
+				"shareholderEquity": 107147000000,
+				"netTangibleAssets": 107147000000,
+				"id": "BALANCE_SHEET",
+				"key": "AAPL",
+				"subkey": "quarterly",
+				"date": 1635273127391,
+				"updated": 1635273127391
+			}
+		]
+	}`
+
+	var nominalBalanceSheets = BalanceSheets{
+		Symbol: "AAPL",
+		Statements: []BalanceSheet{
+			{
+				ReportDate:              Date(time.Date(2020, 10, 17, 0, 0, 0, 0, time.UTC)),
+				FilingType:              "10-K",
+				FiscalDate:              Date(time.Date(2020, 9, 13, 0, 0, 0, 0, time.UTC)),
+				FiscalQuarter:           4,
+				FiscalYear:              2010,
+				Currency:                "USD",
+				CurrentCash:             25913000000,
+				Receivables:             23186000000,
+				Inventory:               3956000000,
+				OtherCurrentAssets:      12087000000,
+				CurrentAssets:           131339000000,
+				LongTermInvestments:     170799000000,
+				PropertyPlantEquipment:  41304000000,
+				OtherAssets:             22283000000,
+				TotalAssets:             365725000000,
+				AccountsPayable:         55888000000,
+				TotalCurrentLiabilities: 116866000000,
+				LongTermDebt:            93735000000,
+				MinorityInterest:        0,
+				TotalLiabilities:        258578000000,
+				CommonStock:             40201000000,
+				RetainedEarnings:        70400000000,
+				ShareholderEquity:       107147000000,
+				NetTangibleAssets:       107147000000,
+			},
+		},
+	}
+
+	testCases := []struct {
+		name string
+
+		// These parameters will be used in the request.
+		requestSymbol string
+		requestPeriod string // annual/quarter
+		requestNumber int
+
+		// These configure the fake response.
+		responseJSON       string
+		responseHTTPStatus int
+
+		// These set our expectations for the test result.
+		wantRequestPath   string
+		wantQueryParams   map[string][]string
+		wantBalanceSheets BalanceSheets
+		wantErr           bool
+	}{
+		{
+			name:              "nominal - annual",
+			requestSymbol:     "aapl",
+			requestPeriod:     "annual",
+			requestNumber:     1,
+			responseJSON:      nominalBalanceSheetJSON,
+			wantRequestPath:   "/stock/aapl/balance-sheet/1",
+			wantQueryParams:   map[string][]string{"token": []string{testToken}, "period": []string{"annual"}},
+			wantBalanceSheets: nominalBalanceSheets,
+		},
+		{
+			name:              "nominal - quarterly",
+			requestSymbol:     "goog",
+			requestPeriod:     "quarter",
+			requestNumber:     2,
+			responseJSON:      nominalBalanceSheetJSON,
+			wantRequestPath:   "/stock/goog/balance-sheet/2",
+			wantQueryParams:   map[string][]string{"token": []string{testToken}, "period": []string{"quarter"}},
+			wantBalanceSheets: nominalBalanceSheets,
+		},
+	}
+
+	for _, tc := range testCases {
+		fakeIEX.ResponseJSON = tc.responseJSON
+		fakeIEX.ResponseHTTPStatus = tc.responseHTTPStatus
+
+		bs, err := client.BalanceSheets(context.TODO(), tc.requestSymbol, tc.requestPeriod, tc.requestNumber)
+		if err != nil {
+			if tc.wantErr {
+				return // error was expected
+			}
+			t.Fatalf("%s: Error getting balance sheets: %s", tc.name, err)
+		}
+		if tc.wantErr {
+			t.Fatalf("%s: Got nil error, want error", tc.name)
+		}
+
+		if diff := deep.Equal(bs, tc.wantBalanceSheets); diff != nil {
+			t.Fatalf("%s: Got unexpected values:\n%s", tc.name, diff)
+		}
+
+		if got, want := fakeIEX.LastURLReceived.Path, tc.wantRequestPath; got != want {
+			t.Errorf("%s: Got %q, want %q", tc.name, got, want)
+		}
+		if diff := deep.Equal(fakeIEX.LastURLReceived.Query(), url.Values(tc.wantQueryParams)); diff != nil {
+			t.Fatalf("%s: Got unexpected values:\n%s", tc.name, diff)
+		}
+	}
+}
 
 // func TestBook(t *testing.T) {
 // 	cfg, err := readConfig("config_test.toml")
@@ -74,11 +193,6 @@ const testToken = "not-a-real-token"
 // 	assertScrambledString(t, "open source", got.Quote.OpenSource, "official")
 // 	isPositiveFloat64(t, "latest price", got.Quote.LatestPrice)
 // }
-
-// Returns the base address for the test server.
-func baseAddress(s *httptest.Server) ClientOption {
-	return WithBaseURL("http://" + s.Listener.Addr().String())
-}
 
 func TestHistoricalPrices(t *testing.T) {
 	fakeIEX := fakeiexcloud.FakeIEXCloud{}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/goinvest/iexcloud/v2
 
 require (
+	github.com/BurntSushi/toml v0.4.1
 	github.com/go-test/deep v1.0.8
 	github.com/google/go-querystring v1.0.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/goinvest/iexcloud/v2
 
 require (
-	github.com/BurntSushi/toml v0.4.1
+	github.com/go-test/deep v1.0.8
 	github.com/google/go-querystring v1.0.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
+github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
-github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
+github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=

--- a/test/fakeiexcloud/fakeiexcloud.go
+++ b/test/fakeiexcloud/fakeiexcloud.go
@@ -1,0 +1,42 @@
+// Package fakeiexcloud implements a fake IEX Cloud service for unit testing.
+package fakeiexcloud
+
+import (
+	"net/http"
+	"net/url"
+)
+
+// FakeIEXCloud is a fake service that just returns whatever you tell it.
+// Use it as follows:
+//
+// fakeIEX := FakeIEXCloud{
+//	 ResponseJSON: <arbitrary JSON string>
+//   ResponseHTTPStatus: <optional non-ok status>
+// }
+// s := httptest.NewServer(http.HandlerFunc(fakeIEX.Handle))
+// defer s.Close()
+//
+// // Then you can create a client object and it will hit our test service.
+// client := NewClient(testToken, WithBaseURL("http://" + s.Listener.Addr().String()))
+type FakeIEXCloud struct {
+	// This response will be given automatically regardless of the request.
+	ResponseJSON       string
+	ResponseHTTPStatus int
+
+	// When a request is received, the URL that was requested will be stored here for inspection.
+	LastURLReceived *url.URL
+}
+
+func (f *FakeIEXCloud) Handle(w http.ResponseWriter, r *http.Request) {
+	f.LastURLReceived = r.URL
+	if f.ResponseHTTPStatus != http.StatusOK && f.ResponseHTTPStatus != 0 {
+		http.Error(w, "Test-injected error", f.ResponseHTTPStatus)
+		return
+	}
+	status := http.StatusOK
+	if f.ResponseHTTPStatus != 0 {
+		status = f.ResponseHTTPStatus
+	}
+	w.WriteHeader(status)
+	w.Write([]byte(f.ResponseJSON))
+}

--- a/test/fakeiexcloud/fakeiexcloud.go
+++ b/test/fakeiexcloud/fakeiexcloud.go
@@ -10,7 +10,7 @@ import (
 // Use it as follows:
 //
 // fakeIEX := FakeIEXCloud{
-//	 ResponseJSON: <arbitrary JSON string>
+//   ResponseJSON: <arbitrary JSON string>
 //   ResponseHTTPStatus: <optional non-ok status>
 // }
 // s := httptest.NewServer(http.HandlerFunc(fakeIEX.Handle))

--- a/test/fakeiexcloud/fakeiexcloud_test.go
+++ b/test/fakeiexcloud/fakeiexcloud_test.go
@@ -1,0 +1,53 @@
+package fakeiexcloud
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNominalUsage(t *testing.T) {
+	// Create a fake client and run a basic 'get' request.
+	f := FakeIEXCloud{ResponseJSON: "blah"}
+	s := httptest.NewServer(http.HandlerFunc(f.Handle))
+	defer s.Close()
+
+	c := http.Client{}
+	resp, err := c.Get("http://" + s.Listener.Addr().String() + "/path")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check the request and responses received.
+	if got, want := f.LastURLReceived.Path, "/path"; got != want {
+		t.Fatalf("Got url path %v, want %v", got, want)
+	}
+	if got, want := string(body), "blah"; got != want {
+		t.Fatalf("Got body %v, want %v", got, want)
+	}
+}
+
+func TestErrorInjection(t *testing.T) {
+	// The error should take precedence over the JSON.
+	f := FakeIEXCloud{ResponseJSON: "blah", ResponseHTTPStatus: http.StatusNotFound}
+	s := httptest.NewServer(http.HandlerFunc(f.Handle))
+	defer s.Close()
+
+	c := http.Client{}
+	resp, err := c.Get("http://" + s.Listener.Addr().String() + "/error-path")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := resp.StatusCode, http.StatusNotFound; got != want {
+		t.Fatalf("Got status %v, want %v", got, want)
+	}
+	if got, want := f.LastURLReceived.Path, "/error-path"; got != want {
+		t.Fatalf("Got url path %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
The previous tests were actually integration tests against the live IEX Cloud service. This PR overhauls them into actual unit tests that don't depend on anything outside the test runner itself. It does this by spinning up a fake in-memory instance of IEX Cloud which just returns whatever you tell it. Then the tests use table-driven test patterns to exercise different corner cases.

This new infrastructure will make adding more tests very simple by copying from these existing examples.