### PR TITLE
fix query param bug

### DIFF
--- a/client.go
+++ b/client.go
@@ -14,7 +14,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -178,11 +177,11 @@ func (c *Client) getBytes(ctx context.Context, address string) ([]byte, error) {
 
 // Returns an URL object that points to the endpoint with optional query parameters.
 func (c *Client) url(endpoint string, queryParams map[string]string) (*url.URL, error) {
-	u, err := url.Parse(c.baseURL)
+	u, err := url.Parse(c.baseURL + endpoint)
 	if err != nil {
 		return nil, err
 	}
-	u.Path = path.Join(u.Path, endpoint)
+
 	if queryParams != nil {
 		q := u.Query()
 		for k, v := range queryParams {


### PR DESCRIPTION
the `url` method will generate a wrong api endpoint with `historicalEndpointWithOpts` called beforehand. For example in `HistoricalPrices` method, in our case we set Sort to desc as HistoricalOptions, then `historicalEndpointWithOpts` will first generate a endpoint like `/stock/{{symbol}}/chart/5dm?sort=desc`, then `url()` will finally generate the url like `https://cloud.iexapis.com/stable/stock/{{symbol}}/chart/5dm%3Fsort=desc?token={{token}}` which will not get the correct response from IEX. So it's a critical issue we found 