### PR TITLE
Remove excess public method for IncomeStatements().

### DIFF
--- a/client.go
+++ b/client.go
@@ -675,18 +675,18 @@ func (c Client) financialsAsReported(ctx context.Context, endpoint string) (Fina
 // AnnualIncomeStatements returns the specified number of most recent annual
 // income statements from the IEX Cloud endpoint for the given stock symbol.
 func (c Client) AnnualIncomeStatements(ctx context.Context, symbol string, num int) (IncomeStatements, error) {
-	return c.IncomeStatements(ctx, symbol, "annual", num)
+	return c.incomeStatements(ctx, symbol, "annual", num)
 }
 
 // QuarterlyIncomeStatements returns the specified number of most recent annual
 // income statements from the IEX Cloud endpoint for the given stock symbol.
 func (c Client) QuarterlyIncomeStatements(ctx context.Context, symbol string, num int) (IncomeStatements, error) {
-	return c.IncomeStatements(ctx, symbol, "quarter", num)
+	return c.incomeStatements(ctx, symbol, "quarter", num)
 }
 
-// IncomeStatements returns the specified number of most recent
+// incomeStatements returns the specified number of most recent
 // income statements from the IEX Cloud endpoint for the given stock symbol and period.
-func (c Client) IncomeStatements(ctx context.Context, symbol string, period string, num int) (IncomeStatements, error) {
+func (c Client) incomeStatements(ctx context.Context, symbol string, period string, num int) (IncomeStatements, error) {
 	endpoint := fmt.Sprintf("/stock/%s/income/%d",
 		url.PathEscape(symbol), num)
 	is := IncomeStatements{}

--- a/client_test.go
+++ b/client_test.go
@@ -331,7 +331,7 @@ func TestIncomeStatements(t *testing.T) {
 		fakeIEX.ResponseJSON = tc.responseJSON
 		fakeIEX.ResponseHTTPStatus = tc.responseHTTPStatus
 
-		incomeStatements, err := client.IncomeStatements(context.TODO(), tc.requestSymbol, tc.requestPeriod, tc.requestNumber)
+		incomeStatements, err := client.incomeStatements(context.TODO(), tc.requestSymbol, tc.requestPeriod, tc.requestNumber)
 		if err != nil {
 			if tc.wantErr {
 				return // error was expected


### PR DESCRIPTION
We can keep hiding the incomeStatements() helper method, no need to make
it public, because it's hard to use this method which needs a specific "period" string.