### PR TITLE
Use floating point numbers for volume in historical query.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -533,6 +533,16 @@ func TestHistoricalPrices(t *testing.T) {
 			}},
 		},
 		{
+			// Sometimes the historical data returns a floating point number for some reason, which
+			// can cause our JSON parsing to fail if we're not ready for it.
+			name:             "corner case - floating point volume",
+			requestSymbol:    "aapl",
+			requestTimeframe: "1y",
+			responseJSON:     `[{ "volume": 118023116.2342521 }]`,
+			wantRequestPath:  "/stock/aapl/chart/1y",
+			wantPrices:       []HistoricalDataPoint{{Volume: 118023116.2342521}},
+		},
+		{
 			name:             "invalid time frame",
 			requestTimeframe: "asdf",
 			responseJSON:     "",

--- a/historical.go
+++ b/historical.go
@@ -117,7 +117,7 @@ type HistoricalDataPoint struct {
 	Low            float64 `json:"low"`
 	Open           float64 `json:"open"`
 	Symbol         string  `json:"symbol"`
-	Volume         int     `json:"volume"`
+	Volume         float64 `json:"volume"`
 	ID             string  `json:"id"`
 	Key            string  `json:"key"`
 	Subkey         string  `json:"subkey"`


### PR DESCRIPTION
I discovered today that sometimes the volume number looks like
NNNNN.NNNNN. I'm still not sure why, but whatever the case it shouldn't
block the query.