### PR TITLE
json: Handle empty HasPaywall data from News

### DIFF
--- a/news.go
+++ b/news.go
@@ -15,5 +15,5 @@ type News struct {
 	Related    string    `json:"related"`
 	Image      string    `json:"image"`
 	Language   string    `json:"lang"`
-	HasPaywall bool      `json:"hasPaywall"`
+	HasPaywall bool      `json:"hasPaywall,omitempty"`
 }


### PR DESCRIPTION
Came across an error parsing news (hasPaywall) - appearing to be missing data (empty string) for the following symbol:

2022/09/06 00:20:39 fetching news for PLMR
**2022/09/06 00:20:39 json: cannot unmarshal string into Go struct field News.hasPaywall of type bool**

It's possible that there should be some more extensive input checking, but this small struct tag update may fix the current existing issue. Apologies - this is my first ever fork/PR, but did run the requisite make (lint/int/etc) to 